### PR TITLE
Added +inf and -inf to myFloat.  Added fix for parsing Significant digits

### DIFF
--- a/src/CmdStan/SummaryParser.hs
+++ b/src/CmdStan/SummaryParser.hs
@@ -69,7 +69,7 @@ parseInputFiles = do
 -- Input file: output.csv
 parseOutputFile :: Parsec String String FilePath
 parseOutputFile = do
-  void $ string "Output csv_file: "
+  void $ string "Ouput csv_file: "
   someTill (satisfy $ const True)
     (lookAhead $ void (char '\n') <|> eof)
 


### PR DESCRIPTION
I see you added the fixes for parsing "nan" and "inf".  Sorry I was slow!  In this PR I added the "+inf" and "-inf" cases.  I also fixed an issue where if the user sets other than the default significant digits, this causes another line of output in the output csv.  I added a parser for it, then optionally parsed where it could happen and ignore the result.